### PR TITLE
Test payment page

### DIFF
--- a/classes/form/test_payment_form.php
+++ b/classes/form/test_payment_form.php
@@ -24,8 +24,8 @@ class test_payment_form extends \moodleform {
     function definition() {
         $mform = $this->_form;
 
-        $mform->addElement('text', 'account number', get_string('paymentaccountnumber', 'tool_paymentplugin'));
-        $mform->setType('account number', PARAM_TEXT);
+        $mform->addElement('text', 'accountnumber', get_string('paymentaccountnumber', 'tool_paymentplugin'));
+        $mform->setType('accountnumber', PARAM_TEXT);
         
         $mform->addElement('password', 'password', get_string('paymentpassword', 'tool_paymentplugin'));
         $mform->setType('password', PARAM_TEXT);

--- a/classes/form/test_payment_form.php
+++ b/classes/form/test_payment_form.php
@@ -14,11 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_paymentplugin\form;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . "/formslib.php");
 
-class testpayment_form extends moodleform {
+class test_payment_form extends \moodleform {
     function definition() {
         $mform = $this->_form;
 
@@ -30,4 +32,8 @@ class testpayment_form extends moodleform {
 
         $this->add_action_buttons(true, get_string('paymentsubmit', 'tool_paymentplugin'));
     }
+
+    //function validation() {
+        
+    //}
 }

--- a/classes/test_payment_form.php
+++ b/classes/test_payment_form.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . "/formslib.php");
+
+class testpayment_form extends moodleform {
+    function definition() {
+        $mform = $this->_form;
+
+        $mform->addElement('text', 'account number', get_string('paymentaccountnumber', 'tool_paymentplugin'));
+        $mform->setType('account number', PARAM_TEXT);
+        
+        $mform->addElement('password', 'password', get_string('paymentpassword', 'tool_paymentplugin'));
+        $mform->setType('password', PARAM_TEXT);
+    }
+}

--- a/classes/test_payment_form.php
+++ b/classes/test_payment_form.php
@@ -27,5 +27,7 @@ class testpayment_form extends moodleform {
         
         $mform->addElement('password', 'password', get_string('paymentpassword', 'tool_paymentplugin'));
         $mform->setType('password', PARAM_TEXT);
+
+        $this->add_action_buttons(true, get_string('paymentsubmit', 'tool_paymentplugin'));
     }
 }

--- a/lang/en/tool_paymentplugin.php
+++ b/lang/en/tool_paymentplugin.php
@@ -35,3 +35,4 @@
     $string['testpaymentpagetitle'] = 'Test Payment';
     $string['paymentaccountnumber'] = 'Account Number:';
     $string['paymentpassword'] = 'Password:';
+    $string['paymentsubmit'] = 'Pay';

--- a/lang/en/tool_paymentplugin.php
+++ b/lang/en/tool_paymentplugin.php
@@ -33,3 +33,5 @@
     $string['GsettingsA_text3_desc'] = 'This textbox allows only emails up to a length of 70.';
 
     $string['testpaymentpagetitle'] = 'Test Payment';
+    $string['paymentaccountnumber'] = 'Account Number:';
+    $string['paymentpassword'] = 'Password:';

--- a/lang/en/tool_paymentplugin.php
+++ b/lang/en/tool_paymentplugin.php
@@ -31,3 +31,5 @@
 
     $string['GsettingsA_text3'] = 'Example Textbox #3';
     $string['GsettingsA_text3_desc'] = 'This textbox allows only emails up to a length of 70.';
+
+    $string['testpaymentpagetitle'] = 'Test Payment';

--- a/test_payment.php
+++ b/test_payment.php
@@ -1,0 +1,13 @@
+<?php
+require_once(__DIR__ . "/../../../config.php");
+require_login();
+
+$PAGE->set_context(CONTEXT_SYSTEM::instance());
+$PAGE->set_url(new moodle_url("/admin/tool/paymentplugin/test_payment_page.php"));
+$PAGE->set_pagelayout("base");
+$PAGE->set_title(get_string('testpaymentpagetitle', 'tool_paymentplugin'));
+$PAGE->set_heading(get_string('testpaymentpagetitle', 'tool_paymentplugin'));
+
+echo $OUTPUT->header();
+
+echo $OUTPUT->footer();

--- a/test_payment.php
+++ b/test_payment.php
@@ -3,15 +3,15 @@ require_once(__DIR__ . "/../../../config.php");
 require_login();
 
 $PAGE->set_context(CONTEXT_SYSTEM::instance());
-$PAGE->set_url(new moodle_url("/admin/tool/paymentplugin/test_payment_page.php"));
+$PAGE->set_url(new moodle_url("/admin/tool/paymentplugin/test_payment.php"));
 $PAGE->set_pagelayout("base");
 $PAGE->set_title(get_string('testpaymentpagetitle', 'tool_paymentplugin'));
 $PAGE->set_heading(get_string('testpaymentpagetitle', 'tool_paymentplugin'));
 
 echo $OUTPUT->header();
 
-require_once(__DIR__ . "/classes/test_payment_form.php");
-$mform = new testpayment_form();
+//require_once(__DIR__ . "/classes/test_payment_form.php");
+$mform = new tool_paymentplugin\form\test_payment_form();
 $mform->display();
 
 

--- a/test_payment.php
+++ b/test_payment.php
@@ -2,7 +2,10 @@
 require_once(__DIR__ . "/../../../config.php");
 require_login();
 
-$PAGE->set_context(CONTEXT_SYSTEM::instance());
+// what data needs to be passed through to this page via url? array of course id's to be purchased?
+$purchases = optional_param_array('purchaseid', null, PARAM_INT);
+
+$PAGE->set_context(CONTEXT_SYSTEM::instance()); //correct context?
 $PAGE->set_url(new moodle_url("/admin/tool/paymentplugin/test_payment.php"));
 $PAGE->set_pagelayout("base");
 $PAGE->set_title(get_string('testpaymentpagetitle', 'tool_paymentplugin'));
@@ -22,10 +25,11 @@ if ($mform->is_cancelled()) {
     // redirect?
     
     
-    // proof the user's information was extracted from form (delete once above is implemented)
+    // just proving that the user's information was extracted from form (delete once above or unit tests are implemented)
     echo "account number: " . $accnumber;
     echo "<br>";
     echo "password: " . $password;
+
 } else {
     $mform->display();
 }

--- a/test_payment.php
+++ b/test_payment.php
@@ -10,9 +10,24 @@ $PAGE->set_heading(get_string('testpaymentpagetitle', 'tool_paymentplugin'));
 
 echo $OUTPUT->header();
 
-//require_once(__DIR__ . "/classes/test_payment_form.php");
 $mform = new tool_paymentplugin\form\test_payment_form();
-$mform->display();
 
+if ($mform->is_cancelled()) {
+    //cancelled
+} else if ($fromform = $mform->get_data()) {
+    $accnumber = $fromform->accountnumber;
+    $password = $fromform->password;
+    // send information to payment gateway api
+
+    // redirect?
+    
+    
+    // proof the user's information was extracted from form (delete once above is implemented)
+    echo "account number: " . $accnumber;
+    echo "<br>";
+    echo "password: " . $password;
+} else {
+    $mform->display();
+}
 
 echo $OUTPUT->footer();

--- a/test_payment.php
+++ b/test_payment.php
@@ -10,4 +10,8 @@ $PAGE->set_heading(get_string('testpaymentpagetitle', 'tool_paymentplugin'));
 
 echo $OUTPUT->header();
 
+require_once(__DIR__ . "/classes/test_payment_form.php");
+$mform = new testpayment_form();
+$mform->display();
+
 echo $OUTPUT->footer();

--- a/test_payment.php
+++ b/test_payment.php
@@ -14,4 +14,5 @@ require_once(__DIR__ . "/classes/test_payment_form.php");
 $mform = new testpayment_form();
 $mform->display();
 
+
 echo $OUTPUT->footer();


### PR DESCRIPTION
Closes #9 
Adds a page `/admin/tool/paymentplugin/test_payment.php` that implements a form which users can input data into and submit.  Form will probably need to be changed once payment gateway side/subplugins are developed further so that data can be sent to them.